### PR TITLE
Fix asynchronous webhook cleanup

### DIFF
--- a/scdlbot/__main__.py
+++ b/scdlbot/__main__.py
@@ -1540,7 +1540,7 @@ def main():
         # https://github.com/python-telegram-bot/python-telegram-bot/discussions/3310
         # https://github.com/python-telegram-bot/python-telegram-bot/wiki/Frequently-requested-design-patterns#running-ptb-alongside-other-asyncio-frameworks
         # https://docs.python-telegram-bot.org/en/v21.5/examples.customwebhookbot.html
-        application.bot.delete_webhook()
+        asyncio.run(application.bot.delete_webhook())
         application.run_polling(
             drop_pending_updates=True,
         )


### PR DESCRIPTION
## Summary
- await bot.delete_webhook before polling

## Testing
- `make test` *(fails: Command not found: doc8)*

------
https://chatgpt.com/codex/tasks/task_e_68470682eacc8330a7a0b20344b1ce54